### PR TITLE
Disable LTO

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,8 +1,0 @@
-[build]
-rustflags = [
-    "-C", "linker=clang",
-    "-C", "linker-plugin-lto=/usr/lib/LLVMgold.so",
-    "-C", "link-arg=-flto=thin",
-    "-C", "link-arg=-fuse-ld=lld",
-    "-C", "target-cpu=native",
-]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Install compatible clang
-        run: |
-          sudo apt-get -y update
-          sudo apt-get -y install clang-10 lld-10
-
-          # Ugly hack to make `cargo` call the right clang when linking
-          dir="$(mktemp -d)"
-          pushd "$dir"
-          ln -s /usr/bin/clang-10 clang
-          popd
-          echo "::add-path::$dir"
       - name: Install Rust nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -44,17 +33,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Install compatible clang
-        run: |
-          sudo apt-get -y update
-          sudo apt-get -y install clang-10 lld-10
-
-          # Ugly hack to make `cargo` call the right clang when linking
-          dir="$(mktemp -d)"
-          pushd "$dir"
-          ln -s /usr/bin/clang-10 clang
-          popd
-          echo "::add-path::$dir"
       - name: Install Rust nightly toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 authors = ["narpfel <narpfel@gmx.de>"]
 edition = "2018"
 
-[profile.release]
-lto = true
-
 [dependencies]
 libc = "0.2"
 

--- a/build.rs
+++ b/build.rs
@@ -12,12 +12,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     cc::Build::new()
         .compiler("clang")
         .flag("-std=c18")
-        .flag("-flto=thin")
         .flag("-Wall")
         .flag("-Wextra")
         .flag("-pedantic")
         .flag("-Werror")
-        .flag("-march=native")
         .file(SOURCE_FILE_NAME)
         .compile("libkilo.a");
 


### PR DESCRIPTION
LTO is too fragile with respect to the `rustc` and `clang` versions
used. This is annoying especially in CI where installing matching
versions is more difficult to do robustly.